### PR TITLE
Fix markdown and typos

### DIFF
--- a/v1/authentication.md
+++ b/v1/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-The Sendwithus API uses [HTTP Basic Authentication](http://en.wikipedia.org/wiki/Basic_access_authentication). All requests require you to authenticate using a Sendwithus API Key as the username with an empty string as the password.
+The sendwithus API uses [HTTP Basic Authentication](http://en.wikipedia.org/wiki/Basic_access_authentication). All requests require you to authenticate using a sendwithus API Key as the username with an empty string as the password.
 
 For example:
 `curl -u live_1234qwerzxcv7890: https://api.sendwithus.com/api/v1`

--- a/v1/customers.md
+++ b/v1/customers.md
@@ -21,7 +21,6 @@ POST `/customers`
 	"data": {
 		"first_name": "Matt",
 		"city": "San Francisco",
-		"nested_list": [1,2,3]
 	}
 }
 ```

--- a/v1/dripcampaign.md
+++ b/v1/dripcampaign.md
@@ -85,7 +85,7 @@ POST `/drip_campaigns/(drip_campaign_id)/activate`
 POST `/drip_campaigns/(drip_campaign_id)/deactivate`
 
 #### Params:
-- recipient_address -- Email address of the customer you would like to remove from the specified campaign.
+- recipient\_address -- Email address of the customer you would like to remove from the specified campaign.
 
 #### Sample Request
 
@@ -114,7 +114,7 @@ POST `/drip_campaigns/(drip_campaign_id)/deactivate`
 POST `/drip_campaigns/deactivate`
 
 #### Params:
-- recipient_address -- Email address of the customer you would like to remove from all drip campaigns.
+- recipient\_address -- Email address of the customer you would like to remove from all drip campaigns.
 
 #### Sample Request
 

--- a/v1/esp.md
+++ b/v1/esp.md
@@ -11,7 +11,7 @@ GET `/esp_accounts`
 
 #### Params:
 
-- esp_type (optional) -- Filter response to only return ESP accounts of a certain type
+- esp\_type (optional) -- Filter response to only return ESP accounts of a certain type
 - count (optional) -- The number of logs to return. *Max: 100, Default: 100.*
 - offset (optional) -- Offset the number of logs to return. *Default: 0*
 
@@ -43,7 +43,7 @@ POST `/esp_accounts`
 
 #### Params:
 
-- send_test_email (optional) -- Send a test email on successful configuration
+- send\_test\_email (optional) -- Send a test email on successful configuration
                                 to the owner(s) of the sendwithus account
 
 #### Sample Request:

--- a/v1/il8n.md
+++ b/v1/il8n.md
@@ -96,4 +96,4 @@ https://api.sendwithus.com/api/v1/i18n/po/international
 
 At send time, Sendwithus uses the `version_name` parameter in the `send` API, and matches it against the template version for that locale. This is why `.po` files must have a filename that matches the locale.
 
-For an example sending with a translated template, please see the [send api](../master/v1/send.md) documentation.
+For an example sending with a translated template, please see the [send api](https://www.sendwithus.com/docs/api#send) documentation.

--- a/v1/logs.md
+++ b/v1/logs.md
@@ -88,7 +88,7 @@ A single Log object with all its details
 }
 ```
 
-## Retrieve events for a specific log_id.
+## Retrieve events for a specific log\_id.
 
 GET `/logs/(:log_id)/events`
 
@@ -96,9 +96,9 @@ Return a list of all events associated with a given Log.
 
 #### Params:
 
-- log_id (required) -- String `log_id` of the Log to retrieve events for.
+- log\_id (required) -- String `log_id` of the Log to retrieve events for.
 
-#### Sample Repsonse:
+#### Sample Response:
 
 ```json
 [
@@ -157,7 +157,7 @@ Resend a specific email by `log_id`.
 }
 ```
 
-#### Sample Repsonse:
+#### Sample Response:
 
 ```json
 {

--- a/v1/render.md
+++ b/v1/render.md
@@ -13,8 +13,8 @@ POST `/render`
 
 - template_id           -- Unique ID obtained from /templates
 - template_data         -- Object containing email template data
-- version_id (optional) -- Unique ID obtained from /templates/(:template_id)/versions
-- version_name (optional) -- Version name that you want rendered (provide either a version_name or a version_id, not both)
+- version\_id (optional) -- Unique ID obtained from /templates/(:template_id)/versions
+- version\_name (optional) -- Version name that you want rendered (provide either a version_name or a version_id, not both)
 
 #### Sample Request:
 

--- a/v1/templates.md
+++ b/v1/templates.md
@@ -180,7 +180,7 @@ POST `/templates/(:template_id)/versions`
 
 *NOTE* -- At least one of html or text must be specified
 
-#### Sample Request
+#### Sample Request:
 
 ```json
 {
@@ -191,7 +191,7 @@ POST `/templates/(:template_id)/versions`
 }
 ```
 
-#### Sample Response
+#### Sample Response:
 
 ```json
 {


### PR DESCRIPTION
Underscores are now properly escaped, so some variables will no longer
be italicized. Fixed a couple of typos too
