### PR TITLE
Fix/Remove unsubscribed_count from drips receipt

### DIFF
--- a/v1/dripcampaign.md
+++ b/v1/dripcampaign.md
@@ -135,8 +135,7 @@ POST `/drip_campaigns/deactivate`
 {
     "success": true,
     "status": "OK",
-    "recipient_address": "customer@example.com",
-    "unsubscribed_count": 14
+    "recipient_address": "customer@example.com"
 }
 ```
 


### PR DESCRIPTION
The docs say we return `unsubscribed_count`, but the API actually doesn't

Correspondingly: https://github.com/sendwithus/sendwithus/pull/1827