### PR TITLE
Add frontmatter to all docs pages for landing app migration

### DIFF
--- a/v1/authentication.md
+++ b/v1/authentication.md
@@ -1,3 +1,8 @@
+---
+title: Authentication
+type: info
+order: 1
+---
 # Authentication
 
 The sendwithus API uses [HTTP Basic Authentication](http://en.wikipedia.org/wiki/Basic_access_authentication).

--- a/v1/batch.md
+++ b/v1/batch.md
@@ -1,3 +1,9 @@
+---
+title: Batch API Requests
+type: api
+order: 12
+---
+
 # Batch API
 
 The sendwithus batch endpoint enables multiple API calls

--- a/v1/clients.md
+++ b/v1/clients.md
@@ -1,3 +1,9 @@
+---
+title: Client Libraries
+type: info
+order: 4
+---
+
 # API Client Libraries
 
 Sendwithus provides API Clients for all major languages and web frameworks. If we're missing a client for your particular use case, please [let us know](mailto:us@sendwithus.com).

--- a/v1/conversions.md
+++ b/v1/conversions.md
@@ -1,3 +1,9 @@
+---
+title: Conversions
+type: api
+order: 7
+---
+
 # Conversions API
 
 **WARNING: This API is currently in beta.**

--- a/v1/customergroups.md
+++ b/v1/customergroups.md
@@ -1,3 +1,9 @@
+---
+title: Groups
+type: api
+order: 10
+---
+
 # Customer Groups API
 
 *NOTE* -- All parameters are mandatory unless otherwise noted.

--- a/v1/customers.md
+++ b/v1/customers.md
@@ -1,3 +1,9 @@
+---
+title: Customers
+type: api
+order: 6
+---
+
 # Customers API
 
 *NOTE* -- All parameters are mandatory unless otherwise noted.

--- a/v1/dripcampaign.md
+++ b/v1/dripcampaign.md
@@ -1,3 +1,9 @@
+---
+title: Drip Campaigns
+type: api
+order: 8
+---
+
 # Drip Campaigns API
 
 ## Activate campaign for a customer

--- a/v1/errors.md
+++ b/v1/errors.md
@@ -1,3 +1,9 @@
+---
+title: Errors
+type: info
+order: 2
+---
+
 # Errors
 
 Any API request will receive a standard HTTP response code.

--- a/v1/esp.md
+++ b/v1/esp.md
@@ -1,3 +1,9 @@
+---
+title: Email Service Providers
+type: api
+order: 5
+---
+
 # ESP Account API
 
 The sendwithus ESP Accounts API allows for fetch and creation of ESP Accounts

--- a/v1/il8n.md
+++ b/v1/il8n.md
@@ -1,3 +1,9 @@
+---
+title: Multi-Language
+type: api
+order: 11
+---
+
 # Internationalization (il8n) API
 
 
@@ -7,9 +13,9 @@
 
 Sendwithus handles internationalization by using *Jinja2* style trans blocks.
 
-The easiest way to set up templates for translation is to use the trans block syntax. A string can be marked for translation by simply wrapping it in a trans block. For example, the internationalized version of "Hello World" is "{% trans %}Hello World{% endtrans %}".
+The easiest way to set up templates for translation is to use the trans block syntax. A string can be marked for translation by simply wrapping it in a trans block. For example, the internationalized version of "Hello World" is "{% raw %}{% trans %}Hello World{% endtrans %}{% endraw %}".
 
-Variables in trans block can be added like normal template variables. For example "Hello {{ name }}"" will become "{% trans %}Hello {{ name }}{% endtrans %}". Multiple variables can be used in the same trans block.
+Variables in trans block can be added like normal template variables. For example "Hello {{ name }}"" will become "{% raw %}{% trans %}Hello {{ name }}{% endtrans %}{% endraw %}". Multiple variables can be used in the same trans block.
 
 Translation packages (.pot files) can be downloaded via API, and then corresponding string files (.po) can be uploaded via API, which will trigger translated template variants to be generated.
 

--- a/v1/logs.md
+++ b/v1/logs.md
@@ -1,3 +1,9 @@
+---
+title: Logs
+type: api
+order: 2
+---
+
 # Logs API
 
 

--- a/v1/overview.md
+++ b/v1/overview.md
@@ -1,3 +1,9 @@
+---
+title: Overview
+type: info
+order: 0
+---
+
 # Overview
 
 The sendwithus API is based on the REST paradigm, and thus features resource based URLs with standard HTTP response codes to indicate errors.  We use standard HTTP authentication and request verbs, and all responses are JSON formatted.

--- a/v1/render.md
+++ b/v1/render.md
@@ -1,3 +1,8 @@
+---
+title: Rendering Templates
+type: api
+order: 4
+---
 # Render API
 
 The render api allows you to render a template with data, using the exact same rendering workflow that Sendwithus uses when delivering your email.

--- a/v1/segments.md
+++ b/v1/segments.md
@@ -1,3 +1,9 @@
+---
+title: Segments
+type: api
+order: 9
+---
+
 # Segments API
 
 *NOTE* -- All parameters are mandatory unless otherwise noted.

--- a/v1/send.md
+++ b/v1/send.md
@@ -1,3 +1,9 @@
+---
+title: Sending Emails
+type: api
+order: 1
+---
+
 # Send API
 
 *NOTE* -- All parameters are mandatory unless otherwise noted.

--- a/v1/snippets.md
+++ b/v1/snippets.md
@@ -1,3 +1,9 @@
+---
+title: Snippets
+type: api
+order: 3
+---
+
 # Snippets API
 
 *NOTE* -- All parameters are mandatory unless otherwise noted.

--- a/v1/status.md
+++ b/v1/status.md
@@ -1,3 +1,9 @@
+---
+title: Status
+type: info
+order: 5
+---
+
 # Sendwithus Status
 
 Sendwithus' application and network status is available here:

--- a/v1/templates.md
+++ b/v1/templates.md
@@ -1,3 +1,9 @@
+---
+title: Templates
+type: api
+order: 0
+---
+
 # Templates API
 
 If no locale is specified in the URL the default locale will be used in all cases.

--- a/v1/versioning.md
+++ b/v1/versioning.md
@@ -1,3 +1,9 @@
+---
+title: Versioning
+type: info
+order: 3
+---
+
 # Versioning
 
 Any time we make backwards-incompatible changes to our API, we will release a new version.  Our current API is v1, with v2 currently under development.


### PR DESCRIPTION
This PR adds the proper YAML frontmatter necessary for the migration to the new static Landing App coming very very soon