### PR TITLE
Remove Segment.com integration from docs

### DIFF
--- a/v1/clients.md
+++ b/v1/clients.md
@@ -26,6 +26,3 @@ All of our API Client Libraries are open source and available in our [Github Acc
 - [Flask - Flask-Sendwithus](https://github.com/jmagnusson/flask-sendwithus) [(jmagnusson)](https://github.com/jmagnusson)
 - [Go - sendwithus_go](https://github.com/elbuo8/sendwithus_go) [(elbuo8)](https://github.com/elbuo8)
 - [Python - sendwithus_py2](https://github.com/bitcasa/sendwithus_py2) [(bitcasa)](https://github.com/bitcasa)
-
-### Segment.com Integration
-Segment is a service that allows single lines in your code to translate to multiple API calls to different services. If you're using Segment, we now have support built in – check out our [Segment setup guide](https://help.sendwithus.com/solution/articles/1000173550-segment-com-triggers) or the [Segment Sendwithus docs](https://segment.com/docs/integrations/sendwithus/) to get started – otherwise, you can start with the [introduction to Segment](https://segment.com/docs/).


### PR DESCRIPTION
This PR is to remove the Segment.com copy from the API Docs.