### PR TITLE
Add message to customers delete endpoint regarding drip campaigns

### DIFF
--- a/v1/clients.md
+++ b/v1/clients.md
@@ -25,4 +25,3 @@ All of our API Client Libraries are open source and available in our [Github Acc
 - [ColdFusion - SendWithUsCfc](https://github.com/philcruz/SendWithUsCfc) [(philcruz)](https://github.com/philcruz)
 - [Flask - Flask-Sendwithus](https://github.com/jmagnusson/flask-sendwithus) [(jmagnusson)](https://github.com/jmagnusson)
 - [Go - sendwithus_go](https://github.com/elbuo8/sendwithus_go) [(elbuo8)](https://github.com/elbuo8)
-- [Python - sendwithus_py2](https://github.com/bitcasa/sendwithus_py2) [(bitcasa)](https://github.com/bitcasa)

--- a/v1/customers.md
+++ b/v1/customers.md
@@ -63,6 +63,8 @@ All parameters are mandatory unless otherwise noted.
 
 `DELETE /customers/(:email)`
 
+*NOTE* -- Deleting customers **will not** remove any pending scheduled drip campaign emails. To prevent these emails from being delivered, you must deactivate the user using the [Drip Campaign Deactivation endpoint](https://support.sendwithus.com/api/#deactivateacustomerfromallcampaigns).
+
 #### Sample Response:
 
 ```javascript

--- a/v1/i18n.md
+++ b/v1/i18n.md
@@ -25,7 +25,7 @@ This call will fetch a .pot translation package for all templates that have been
 
 #### Params:
 
-- tag       -- String will return a .pot file only for templates that have the corresponding tag. Tags are set in the [dashboard](https://www.sendwithus.com/#/emails)
+- tag       -- String will return a .pot file only for templates that have the corresponding tag. Tags can be set via the [Sendwithus dashboard](https://support.sendwithus.com/templating/how_to_add_tags/).
 
 ### Examples
 
@@ -84,7 +84,7 @@ Post translations.zip for templates with tag "international".
 
 At send time, Sendwithus uses the _locale_ parameter in the Send API, and matches it against the template version for that locale. This is why .po files must have a filename that matches the locale.
 
-For an example sending with a translated template, please see the [send api](https://www.sendwithus.com/docs/api#send) documentation.
+For an example sending with a translated template, please see the [send API](https://support.sendwithus.com/api/#sendapi) documentation.
 
 ## Locale Code Standards
 


### PR DESCRIPTION
This PR adds a note to the customers delete endpoint where pending drip campaign emails will still be scheduled. This PR also fixes a couple broken links and removes an API client that is no longer available.