### PR TITLE
Adding si-LK to supported locales

### DIFF
--- a/v1/i18n.md
+++ b/v1/i18n.md
@@ -314,6 +314,7 @@ The Locale codes that we currently support are as follows:
 	ro-RO => Romanian (Romania)
 	ru-KZ => Russian (Kazakhstan)
 	ru-RU => Russian (Russia)
+	si-LK => Sinhala (Sri Lanka)
 	sk-SK => Slovak (Slovakia)
 	sl-SI => Slovenian (Slovenia)
 	sq-AL => Albanian (Albania)


### PR DESCRIPTION
Updating API documentation to include si-LK => Sinhala (Sri Lanka) as a supported locale code